### PR TITLE
Added public model storage for public models

### DIFF
--- a/snetd/cmd/components.go
+++ b/snetd/cmd/components.go
@@ -64,6 +64,7 @@ type Components struct {
 	modelUserStorage           *training.ModelUserStorage
 	modelStorage               *training.ModelStorage
 	pendingModelStorage        *training.PendingModelStorage
+	publicModelStorage         *training.PublicModelStorage
 }
 
 func InitComponents(cmd *cobra.Command) (components *Components) {
@@ -561,11 +562,23 @@ func (components *Components) ConfigurationService() *configuration_service.Conf
 	return components.configurationService
 }
 
+func (components *Components) ModelStorage() *training.ModelStorage {
+	if components.modelStorage != nil {
+		return components.modelStorage
+	}
+
+	components.modelStorage = training.NewModelStorage(components.AtomicStorage())
+
+	return components.modelStorage
+}
+
 func (components *Components) ModelUserStorage() *training.ModelUserStorage {
 	if components.modelUserStorage != nil {
 		return components.modelUserStorage
 	}
+
 	components.modelUserStorage = training.NewUserModelStorage(components.AtomicStorage())
+
 	return components.modelUserStorage
 }
 
@@ -573,16 +586,20 @@ func (components *Components) PendingModelStorage() *training.PendingModelStorag
 	if components.pendingModelStorage != nil {
 		return components.pendingModelStorage
 	}
+
 	components.pendingModelStorage = training.NewPendingModelStorage(components.AtomicStorage())
+
 	return components.pendingModelStorage
 }
 
-func (components *Components) ModelStorage() *training.ModelStorage {
-	if components.modelStorage != nil {
-		return components.modelStorage
+func (components *Components) PublicModelStorage() *training.PublicModelStorage {
+	if components.publicModelStorage != nil {
+		return components.publicModelStorage
 	}
-	components.modelStorage = training.NewModelStorage(components.AtomicStorage())
-	return components.modelStorage
+
+	components.publicModelStorage = training.NewPublicModelStorage(components.AtomicStorage())
+
+	return components.publicModelStorage
 }
 
 func (components *Components) TrainingService() training.DaemonServer {
@@ -594,8 +611,12 @@ func (components *Components) TrainingService() training.DaemonServer {
 		return components.trainingService
 	}
 
-	components.trainingService = training.NewTrainingService(components.PaymentChannelService(), components.ServiceMetaData(),
-		components.OrganizationMetaData(), components.ModelStorage(), components.ModelUserStorage(), components.PendingModelStorage())
+	components.trainingService = training.NewTrainingService(
+		components.PaymentChannelService(), components.ServiceMetaData(),
+		components.OrganizationMetaData(), components.ModelStorage(),
+		components.ModelUserStorage(), components.PendingModelStorage(),
+		components.PublicModelStorage())
+
 	return components.trainingService
 }
 

--- a/training/service.go
+++ b/training/service.go
@@ -58,6 +58,7 @@ type DaemonService struct {
 	storage              *ModelStorage
 	userStorage          *ModelUserStorage
 	pendingStorage       *PendingModelStorage
+	publicStorage        *PublicModelStorage
 	serviceUrl           string
 	trainingMetadata     *TrainingMetadata
 	methodsMetadata      map[string]*MethodMetadata
@@ -70,6 +71,7 @@ func NewDaemonsService(
 	storage *ModelStorage,
 	userStorage *ModelUserStorage,
 	pendingStorage *PendingModelStorage,
+	publicStorage *PublicModelStorage,
 	serviceUrl string,
 	trainingMedadata *TrainingMetadata,
 	methodsMetadata map[string]*MethodMetadata,
@@ -81,6 +83,7 @@ func NewDaemonsService(
 		storage:              storage,
 		userStorage:          userStorage,
 		pendingStorage:       pendingStorage,
+		publicStorage:        publicStorage,
 		serviceUrl:           serviceUrl,
 		trainingMetadata:     trainingMedadata,
 		methodsMetadata:      methodsMetadata,
@@ -903,7 +906,8 @@ func (ds *DaemonService) GetModel(c context.Context, request *CommonRequest) (re
 
 // NewTrainingService daemon self server
 func NewTrainingService(channelService escrow.PaymentChannelService, serMetaData *blockchain.ServiceMetadata,
-	orgMetadata *blockchain.OrganizationMetaData, storage *ModelStorage, userStorage *ModelUserStorage, pendingStorage *PendingModelStorage) DaemonServer {
+	orgMetadata *blockchain.OrganizationMetaData, storage *ModelStorage, userStorage *ModelUserStorage,
+	pendingStorage *PendingModelStorage, publicStorage *PublicModelStorage) DaemonServer {
 
 	linkerFiles := getFileDescriptors(serMetaData.ProtoFiles)
 	serMetaData.ProtoDescriptors = linkerFiles
@@ -923,6 +927,7 @@ func NewTrainingService(channelService escrow.PaymentChannelService, serMetaData
 			storage:              storage,
 			userStorage:          userStorage,
 			pendingStorage:       pendingStorage,
+			publicStorage:        publicStorage,
 			serviceUrl:           serviceURL,
 			trainingMetadata:     &trainMD,
 			methodsMetadata:      methodsMD,

--- a/training/tests/integration/daemon_service_test.go
+++ b/training/tests/integration/daemon_service_test.go
@@ -22,7 +22,7 @@ type DaemonServiceSuite struct {
 	modelStorage        *training.ModelStorage
 	userModelStorage    *training.ModelUserStorage
 	pendingModelStorage *training.PendingModelStorage
-	daemonService       *training.DaemonService
+	daemonService       training.DaemonServer
 	modelKeys           []*training.ModelKey
 	grpcServer          *grpc.Server
 }
@@ -36,7 +36,7 @@ var (
 func (suite *DaemonServiceSuite) SetupSuite() {
 	suite.setupTestConfig()
 
-	modelKeys, modelStorage, userModelStorage, pendingModelStorage := suite.createTestModels()
+	modelKeys, modelStorage, userModelStorage, pendingModelStorage, publicModelStorage := suite.createTestModels()
 	suite.modelKeys = modelKeys
 	suite.modelStorage = modelStorage
 	suite.userModelStorage = userModelStorage
@@ -48,8 +48,14 @@ func (suite *DaemonServiceSuite) SetupSuite() {
 		zap.L().Fatal("Error in initinalize organization metadata from json", zap.Error(err))
 	}
 
-	suite.daemonService = training.NewDaemonsService(
-		serviceMetadata, orgMetadata, nil, modelStorage, userModelStorage, pendingModelStorage, nil, "http://localhost:5001", nil, nil,
+	suite.daemonService = training.NewTrainingService(
+		nil,
+		serviceMetadata,
+		orgMetadata,
+		modelStorage,
+		userModelStorage,
+		pendingModelStorage,
+		publicModelStorage,
 	)
 
 	address := "localhost:5001"
@@ -101,6 +107,7 @@ func (suite *DaemonServiceSuite) setupTestConfig() {
 		},
 		"hooks": []
 	},
+	"model_maintenance_endpoint": "http://localhost:5001",
 	"payment_channel_storage_client": {
 		"connection_timeout": "0s",
 		"request_timeout": "0s",
@@ -135,11 +142,13 @@ func (suite *DaemonServiceSuite) setupTestConfig() {
 	config.SetVip(testConfig)
 }
 
-func (suite *DaemonServiceSuite) createTestModels() ([]*training.ModelKey, *training.ModelStorage, *training.ModelUserStorage, *training.PendingModelStorage) {
+func (suite *DaemonServiceSuite) createTestModels() ([]*training.ModelKey,
+	*training.ModelStorage, *training.ModelUserStorage, *training.PendingModelStorage, *training.PublicModelStorage) {
 	memStorage := storage.NewMemStorage()
 	modelStorage := training.NewModelStorage(memStorage)
 	userModelStorage := training.NewUserModelStorage(memStorage)
 	pendingModelStorage := training.NewPendingModelStorage(memStorage)
+	publicModelStorage := training.NewPublicModelStorage(memStorage)
 
 	modelA := &training.ModelData{
 		IsPublic:            true,
@@ -209,7 +218,7 @@ func (suite *DaemonServiceSuite) createTestModels() ([]*training.ModelKey, *trai
 
 	pendingModelStorage.Put(key, pendingModelsData)
 
-	return modelKeys, modelStorage, userModelStorage, pendingModelStorage
+	return modelKeys, modelStorage, userModelStorage, pendingModelStorage, publicModelStorage
 }
 
 func (suite *DaemonServiceSuite) TestRunDaemonService() {
@@ -218,8 +227,6 @@ func (suite *DaemonServiceSuite) TestRunDaemonService() {
 	deadline := time.Now().Add(duration)
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
-
-	suite.daemonService.ManageUpdateModelStatusWorkers(ctx, time.Second*3, "test_org_id", "service_id", "99ybRIg2wAx55mqVsA6sB4S7WxPQHNKqa4BPu/bhj+U=")
 
 	select {
 	case <-ctx.Done():

--- a/training/tests/integration/daemon_service_test.go
+++ b/training/tests/integration/daemon_service_test.go
@@ -49,7 +49,7 @@ func (suite *DaemonServiceSuite) SetupSuite() {
 	}
 
 	suite.daemonService = training.NewDaemonsService(
-		serviceMetadata, orgMetadata, nil, modelStorage, userModelStorage, pendingModelStorage, "http://localhost:5001", nil, nil,
+		serviceMetadata, orgMetadata, nil, modelStorage, userModelStorage, pendingModelStorage, nil, "http://localhost:5001", nil, nil,
 	)
 
 	address := "localhost:5001"

--- a/training/tests/unit/storage_test.go
+++ b/training/tests/unit/storage_test.go
@@ -16,6 +16,7 @@ type ModelStorageSuite struct {
 	storage           *training.ModelStorage
 	userStorage       *training.ModelUserStorage
 	pendingStorage    *training.PendingModelStorage
+	publicStorage     *training.PublicModelStorage
 	organizationId    string
 	serviceId         string
 	groupId           string
@@ -35,6 +36,11 @@ func (suite *ModelStorageSuite) getUserModelKey(address string) *training.ModelU
 
 func (suite *ModelStorageSuite) getPendingModelKey() *training.PendingModelKey {
 	return &training.PendingModelKey{OrganizationId: suite.organizationId, ServiceId: suite.serviceId,
+		GroupId: suite.groupId}
+}
+
+func (suite *ModelStorageSuite) getPublicModelKey() *training.PublicModelKey {
+	return &training.PublicModelKey{OrganizationId: suite.organizationId, ServiceId: suite.serviceId,
 		GroupId: suite.groupId}
 }
 
@@ -68,11 +74,18 @@ func (suite *ModelStorageSuite) getPendingModelData(modelIds []string) *training
 	}
 }
 
+func (suite *ModelStorageSuite) getPublicModelData(modelIds []string) *training.PublicModelData {
+	return &training.PublicModelData{
+		ModelIDs: modelIds,
+	}
+}
+
 func (suite *ModelStorageSuite) SetupSuite() {
 	suite.memoryStorage = base_storage.NewMemStorage()
 	suite.storage = training.NewModelStorage(suite.memoryStorage)
-	suite.userStorage = training.NewUserModelStorage(base_storage.NewMemStorage())
-	suite.pendingStorage = training.NewPendingModelStorage(base_storage.NewMemStorage())
+	suite.userStorage = training.NewUserModelStorage(suite.memoryStorage)
+	suite.pendingStorage = training.NewPendingModelStorage(suite.memoryStorage)
+	suite.publicStorage = training.NewPublicModelStorage(suite.memoryStorage)
 	suite.accessibleAddress = make([]string, 2)
 	suite.accessibleAddress[0] = "ADD1"
 	suite.accessibleAddress[1] = "ADD2"
@@ -86,7 +99,6 @@ func TestFreeCallUserStorageSuite(t *testing.T) {
 }
 
 func (suite *ModelStorageSuite) TestModelStorage_GetAll() {
-
 	key1 := suite.getModelKey("1")
 	key2 := suite.getModelKey("2")
 	data1 := suite.getModelData("1")
@@ -145,6 +157,15 @@ func (suite *ModelStorageSuite) Test_serializePendingModelKey() {
 	expectedSerializedKey := fmt.Sprintf("{ID:%v|%v|%v}", suite.organizationId, suite.serviceId, suite.groupId)
 
 	key := suite.getPendingModelKey()
+	serializedKey := key.String()
+
+	assert.Equal(suite.T(), expectedSerializedKey, serializedKey)
+}
+
+func (suite *ModelStorageSuite) Test_serializePublicModelKey() {
+	expectedSerializedKey := fmt.Sprintf("{ID:%v|%v|%v}", suite.organizationId, suite.serviceId, suite.groupId)
+
+	key := suite.getPublicModelKey()
 	serializedKey := key.String()
 
 	assert.Equal(suite.T(), expectedSerializedKey, serializedKey)
@@ -218,6 +239,19 @@ func (suite *ModelStorageSuite) TestPendingModelStorage_Get() {
 	assert.NoError(suite.T(), err)
 
 	newData, ok, err := suite.pendingStorage.Get(key)
+	assert.True(suite.T(), ok)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), data, newData)
+}
+
+func (suite *ModelStorageSuite) TestPublicModelStorage_Get() {
+	key := suite.getPublicModelKey()
+	data := suite.getPublicModelData([]string{"1", "2"})
+
+	err := suite.publicStorage.Put(key, data)
+	assert.NoError(suite.T(), err)
+
+	newData, ok, err := suite.publicStorage.Get(key)
 	assert.True(suite.T(), ok)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), data, newData)

--- a/training/tests/unit/storage_test.go
+++ b/training/tests/unit/storage_test.go
@@ -244,6 +244,27 @@ func (suite *ModelStorageSuite) TestPendingModelStorage_Get() {
 	assert.Equal(suite.T(), data, newData)
 }
 
+func (suite *ModelStorageSuite) TestPendingModelStorage_AddPendingModelId() {
+	key := suite.getPendingModelKey()
+	data := suite.getPendingModelData([]string{"1", "2"})
+
+	err := suite.pendingStorage.Put(key, data)
+	assert.NoError(suite.T(), err)
+
+	newData, ok, err := suite.pendingStorage.Get(key)
+	assert.True(suite.T(), ok)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), data, newData)
+
+	newModelId := "3"
+	data = suite.getPendingModelData([]string{"1", "2", "3"})
+	err = suite.pendingStorage.AddPendingModelId(key, newModelId)
+	assert.NoError(suite.T(), err)
+	newData, ok, err = suite.pendingStorage.Get(key)
+	assert.True(suite.T(), ok)
+	assert.Equal(suite.T(), data, newData)
+}
+
 func (suite *ModelStorageSuite) TestPublicModelStorage_Get() {
 	key := suite.getPublicModelKey()
 	data := suite.getPublicModelData([]string{"1", "2"})
@@ -254,5 +275,26 @@ func (suite *ModelStorageSuite) TestPublicModelStorage_Get() {
 	newData, ok, err := suite.publicStorage.Get(key)
 	assert.True(suite.T(), ok)
 	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), data, newData)
+}
+
+func (suite *ModelStorageSuite) TestPublicModelStorage_AddPublicModelId() {
+	key := suite.getPublicModelKey()
+	data := suite.getPublicModelData([]string{"1", "2"})
+
+	err := suite.publicStorage.Put(key, data)
+	assert.NoError(suite.T(), err)
+
+	newData, ok, err := suite.publicStorage.Get(key)
+	assert.True(suite.T(), ok)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), data, newData)
+
+	newModelId := "3"
+	data = suite.getPublicModelData([]string{"1", "2", "3"})
+	err = suite.publicStorage.AddPublicModelId(key, newModelId)
+	assert.NoError(suite.T(), err)
+	newData, ok, err = suite.publicStorage.Get(key)
+	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), data, newData)
 }


### PR DESCRIPTION
1) Removed NewDaemonService; tests now use NewTrainingService;
2) Improved data update approach: added AddPendingModelID and AddPublicModelID methods;
3) Added tests for public storage, AddPendingModelID, and AddPublicModelID;
4) Updated createModelDetails, GetAllModel, GetModel to use publicModelStorage.